### PR TITLE
Explicitly specify the image in the gitlab-ci-example

### DIFF
--- a/gitlab-ci-example.yml
+++ b/gitlab-ci-example.yml
@@ -1,3 +1,5 @@
+image: debian:bullseye-slim
+
 before_script:
     - ln -fs /usr/share/zoneinfo/Europe/Vienna /etc/localtime
     - apt update -y


### PR DESCRIPTION
If no image gets specified in the `.gitab-ci.yml`-File, the gitlab-runner uses the image that got specified while registering the runner.  
Since this does not necessarily have to be a `debian` image I would suggest to set the image explicitly.