### PR TITLE
Gitlab-CI Example using Alpine as Baseimage

### DIFF
--- a/gitlab-ci-example-alpine.yml
+++ b/gitlab-ci-example-alpine.yml
@@ -1,0 +1,20 @@
+image: alpine:3.16
+
+before_script:
+    - apk update
+    - apk add git cmake qemu qemu-img qemu-system-x86_64 qemu-system-i386 gcc g++ make libc-dev python3 py3-yaml
+
+build:
+  stage: build
+  script:
+    - echo "Building newest commit in $CI_COMMIT_BRANCH!"
+    - sh setup_cmake.sh
+    - cd /tmp/sweb
+    - make -j$(nproc)
+
+tortillas:
+  stage: test
+  script:
+    - git clone https://github.com/PaideiaDilemma/Tortillas.git ./tortillas
+    - cd tortillas
+    - python3 -m tortillas -S ..


### PR DESCRIPTION
Because of overhead, my group used `alpine` images (mainly to safe bandwith).  
I adapted your example accordingly.

It also has to be noted, that `qemu-utils` contains `qemu-img`, `qemu-io` and `qemu-nbd` (according to [Debian Bullseye Paket: qemu-utils](https://packages.debian.org/bullseye/qemu-utils))
However, Alpine packages them individually. According to my tests, Tortillas should only need `qemu-img`.

Also, the Debian package `qemu-system-x86` contains `qemu-system-x86_64` and `qemu-system-i386`, which are individually packaged by alpine. I have added both in the example config.