### PR TITLE
failure detection fixes & clean qemu shutdown

### DIFF
--- a/tortillas/log_analyzer.py
+++ b/tortillas/log_analyzer.py
@@ -142,8 +142,11 @@ class LogAnalyzer:
                 else TestStatus[config_entry.set_status]
             )
 
-            if not logs:
-                continue
+            # fixme: this is flawed, why is this here?
+            #  when tortillas gets no logs and and aborts, it can't detect incorrect or missing exit codes
+            #  as a result, every test with incorrect exit codes passes
+            # if not logs:
+            #     continue
 
             if config_entry.mode == "add_as_error":
                 result.add_errors(logs, status)

--- a/tortillas/test_runner.py
+++ b/tortillas/test_runner.py
@@ -186,7 +186,7 @@ class TestRunner:
         # Testing finished
 
         self.success = not any(
-            test_run.result.status in (TestStatus.FAILED, TestStatus.PANIC)
+            test_run.result.status in (TestStatus.FAILED, TestStatus.PANIC, TestStatus.TIMEOUT)
             for test_run in self.test_runs
         )
 

--- a/tortillas/test_runner.py
+++ b/tortillas/test_runner.py
@@ -381,8 +381,12 @@ def _run(
 
         # Wait a bit for cleanup and debug output to be flushed
         time.sleep(1)
+        # analyze before exiting the shell, to keep exit codes intact
+        test.analyze(status)
 
-    test.analyze(status)
+        # exit the shell, so files are written to the qcow2 image
+        qemu.sweb_input("exit\n")
+        time.sleep(1)
 
     log.info("Done!")
     if callback:


### PR DESCRIPTION
During this semester of OS, we had the pleasure of using your tool.
We noticed some issues with test status detection:
+ timeouts were displayed in the log, but not counted towards the overall status. As such, when all tests either pass *or timeout*, tortillas yields success as the exit code.
+ if someone disabled vital kernel logs (i.e. SYSCALL for exit code detection), tortillas didn't detect any failures and marked tests as success. In our opinion, it should instead mark tests expecting a specific exit code as failed, since no exit code was found at all.

Additionally, we added a clean QEMU shutdown, so changes to the file system are committed to disk. One may then inspect the image and its contents afterwards.